### PR TITLE
Add key 'rpa' to features map to quell client-side warnings

### DIFF
--- a/src/Servers.cpp
+++ b/src/Servers.cpp
@@ -1101,6 +1101,10 @@ QVariantMap Server::makeFeaturesDictForConnection(AbstractConnection *c, const Q
     if (hasCashTokens)
         r["cashtokens"] = true;
 
+    // RPA TODO: in the final release make RPA support configurable and make this true/false based on the config setting
+    // if (opts.rpaEnabled)
+    r["rpa"] = true;
+
     QVariantMap hmap, hmapTor;
     if (opts.publicTcp.has_value())
         hmap["tcp_port"] = unsigned(*opts.publicTcp);


### PR DESCRIPTION
This quells the client-side warning that you are not connected to an rpa server.
