### PR TITLE
Optimize CPU usage slightly and also refactor

### DIFF
--- a/Fulcrum.pro
+++ b/Fulcrum.pro
@@ -397,6 +397,16 @@ HEADERS += \
 # Robin Hood unordered_flat_map implememntation (single header and MUCH more efficient than unordered_map!)
 HEADERS += robin_hood/robin_hood.h
 
+# Tessil hat-trie implememntation (header only, supports prefix search and fast serialization/deserialization!)
+HEADERS += \
+    tsl/htrie_set.h \
+    tsl/htrie_map.h \
+    tsl/htrie_hash.h \
+    tsl/array-hash/array_set.h \
+    tsl/array-hash/array_map.h \
+    tsl/array-hash/array_growth_policy.h \
+    tsl/array-hash/array_hash.h
+
 RESOURCES += \
     resources.qrc
 

--- a/src/BTC.h
+++ b/src/BTC.h
@@ -21,6 +21,7 @@
 #include "Util.h"
 
 #include "bitcoin/block.h"
+#include "bitcoin/hash.h"
 #include "bitcoin/script.h"
 #include "bitcoin/streams.h"
 #include "bitcoin/transaction.h"
@@ -170,6 +171,15 @@ namespace BTC
     inline QByteArray HashOnce(const QByteArray &b) { return Hash(b, true); }
     /// Like the Hash() function above, except does hash160 once. (not reversed).
     extern QByteArray Hash160(const QByteArray &);
+    /// Hash any Bitcoin object in-place and return the hash. If `once` == true, we do single-sha256 hashing. If
+    /// `reversed` == true, we reverse the result (making it big-endian ready for JSON).
+    template <typename BitcoinObject>
+    QByteArray HashInPlace(const BitcoinObject &bo, bool once = false, bool reversed = false) {
+        QByteArray ret(bitcoin::CHash256::OUTPUT_SIZE, Qt::Uninitialized); // allocate without initializing
+        bitcoin::SerializeHashInPlace(ret.data(), bo, bitcoin::SER_GETHASH, bitcoin::PROTOCOL_VERSION, once);
+        if (reversed) std::reverse(ret.begin(), ret.end());
+        return ret;
+    }
 
     /// Takes a hash in bitcoin memory order and returns a deep copy QByteArray of the data, reversed
     /// (this is intended to keep our representation of bitcoin data closer to how we will send it to clients down

--- a/src/ReusableBlock.cpp
+++ b/src/ReusableBlock.cpp
@@ -16,9 +16,102 @@
 // along with this program (see LICENSE.txt).  If not, see
 // <https://www.gnu.org/licenses/>.
 //
+#include "ReusableBlock.h"
+
+#include <cstring> // for std::memcpy
+#include <type_traits>
+
+namespace {
+// we can save some space on disk by using uint32_t - max size is dependent on block, so if blocks overflow uint32::max txs this could fail
+using HATSerializationVectorSizeType = uint32_t;
+
+struct ReusableHATSerializer {
+    QByteArray store;
+
+    ReusableHATSerializer() {}
+
+    template <typename T, std::enable_if_t<std::is_arithmetic_v<T>>* = nullptr> // required support for uint64_t and float (WHY float? see https://github.com/Tessil/hat-trie note about serialization)
+    void operator()(const T& value) {
+        store.append(reinterpret_cast<const char*>(&value), sizeof(T));
+    }
+
+    void operator()(const PrefixMap::mapped_type& value) { // specialize for our list of TxNums
+        HATSerializationVectorSizeType size = value.size();
+        store.append(reinterpret_cast<const char*>(&size), sizeof(size));
+        store.append(reinterpret_cast<const char*>(value.data()), size * sizeof(TxNum));
+    }
+
+    void operator()(const char* value, std::size_t value_size) {
+        store.append(reinterpret_cast<const char*>(value), value_size);
+    }
+};
+
+struct ReusableHATDeserializer {
+    QByteArray store;
+    size_t offset = 0u;
+
+    explicit ReusableHATDeserializer(const QByteArray &store_): store(store_) {}
+
+    template <typename T,
+              std::enable_if_t<std::is_arithmetic_v<T>>* = nullptr> // required support for uint64_t and float (see note above)
+    T operator()() {
+        checkReadSizeOk(sizeof(T));
+        T value;
+        std::memcpy(reinterpret_cast<char*>(&value), store.constData() + offset, sizeof(T));
+        offset += sizeof(T);
+        return value;
+    }
+
+    template <typename T,
+              std::enable_if_t<! std::is_arithmetic_v<T>>* = nullptr> // invert the above specialzation for vector (TODO make this more clean)
+    T operator()() { // specialization on our value type for deserialization
+        static_assert(std::is_same_v<T, PrefixMap::mapped_type>);
+        HATSerializationVectorSizeType size = 0;
+        size_t bytesToRead = sizeof(size);
+        checkReadSizeOk(bytesToRead);
+        std::memcpy(reinterpret_cast<char*>(&size), store.constData() + offset, bytesToRead);
+        offset += bytesToRead;
+
+        static_assert(std::is_same_v<TxNum, PrefixMap::mapped_type::value_type>);
+        bytesToRead = size * sizeof(TxNum); // read "size" TxNums
+        checkReadSizeOk(bytesToRead);
+        PrefixMap::mapped_type value(size, TxNum{}); // resize our vector so we can copy into it without causing explosion
+        std::memcpy(reinterpret_cast<char*>(value.data()), store.constData() + offset, bytesToRead);
+        offset += bytesToRead;
+
+        return value;
+    }
+
+    void operator()(char* value_out, size_t value_size) {
+        checkReadSizeOk(value_size);
+        std::memcpy(value_out, store.constData() + offset, value_size);
+        offset += value_size;
+    }
+
+private:
+    void checkReadSizeOk(const size_t bytesToRead) const {
+        if (offset + bytesToRead > static_cast<size_t>(store.size()))
+            throw InternalError("Attempt to read past end of buffer");
+    }
+};
+
+} // namespace
+
+QByteArray ReusableBlock::toBytes() const {
+    ReusableHATSerializer serializer;
+    pmap.serialize(serializer);
+    return serializer.store;
+}
+
+/* static */ ReusableBlock ReusableBlock::fromBytes(const QByteArray &ba) {
+    ReusableHATDeserializer deserializer(ba);
+    ReusableBlock ret;
+    ret.pmap = PrefixMap::deserialize(deserializer);
+    return ret;
+}
+
 #ifdef ENABLE_TESTS
 #include "App.h"
-#include "ReusableBlock.h"
 
 #include <QRandomGenerator>
 

--- a/src/ReusableBlock.h
+++ b/src/ReusableBlock.h
@@ -25,92 +25,18 @@
 #include "bitcoin/transaction.h"
 #include "tsl/htrie_map.h"
 
-#include <QString>
+#include <QByteArray>
 
 #include <cstddef>
 #include <cstdint>
-#include <cstring> // for std::memcpy
-#include <type_traits>
+#include <string>
+#include <vector>
 
 // Our prefixes are lower 4 bits inside char
 using PrefixNibble = char;
 
 // TODO provide description of data here
 using PrefixMap = tsl::htrie_map<PrefixNibble, std::vector<TxNum>, tsl::ah::str_hash<PrefixNibble>, std::uint8_t>;
-
-// we can save some space on disk by using uint32_t - max size is dependent on block, so if blocks overflow uint32::max txs this could fail
-using HATSerializationVectorSizeType = uint32_t;
-
-struct ReusableHATSerializer {
-    QByteArray store;
-
-    ReusableHATSerializer() {}
-
-    template <typename T, std::enable_if_t<std::is_arithmetic_v<T>>* = nullptr> // required support for uint64_t and float (WHY float? see https://github.com/Tessil/hat-trie note about serialization)
-    void operator()(const T& value) {
-        store.append(reinterpret_cast<const char*>(&value), sizeof(T));
-    }
-
-    void operator()(const PrefixMap::mapped_type& value) { // specialize for our list of TxNums
-        HATSerializationVectorSizeType size = value.size();
-        store.append(reinterpret_cast<const char*>(&size), sizeof(size));
-        store.append(reinterpret_cast<const char*>(value.data()), size * sizeof(TxNum));
-    }
-
-    void operator()(const char* value, std::size_t value_size) {
-        store.append(reinterpret_cast<const char*>(value), value_size);
-    }
-};
-
-struct ReusableHATDeserializer {
-    QByteArray store;
-    size_t offset = 0u;
-
-    explicit ReusableHATDeserializer(const QByteArray &store_): store(store_) {}
-
-    template <typename T,
-              std::enable_if_t<std::is_arithmetic_v<T>>* = nullptr> // required support for uint64_t and float (see note above)
-    T operator()() {
-        checkReadSizeOk(sizeof(T));
-        T value;
-        std::memcpy(reinterpret_cast<char*>(&value), store.constData() + offset, sizeof(T));
-        offset += sizeof(T);
-        return value;
-    }
-
-    template <typename T,
-              std::enable_if_t<! std::is_arithmetic_v<T>>* = nullptr> // invert the above specialzation for vector (TODO make this more clean)
-    T operator()() { // specialization on our value type for deserialization
-        static_assert(std::is_same_v<T, PrefixMap::mapped_type>);
-        HATSerializationVectorSizeType size = 0;
-        size_t bytesToRead = sizeof(size);
-        checkReadSizeOk(bytesToRead);
-        std::memcpy(reinterpret_cast<char*>(&size), store.constData() + offset, bytesToRead);
-        offset += bytesToRead;
-
-        static_assert(std::is_same_v<TxNum, PrefixMap::mapped_type::value_type>);
-        bytesToRead = size * sizeof(TxNum); // read "size" TxNums
-        checkReadSizeOk(bytesToRead);
-        PrefixMap::mapped_type value(size, TxNum{}); // resize our vector so we can copy into it without causing explosion
-        std::memcpy(reinterpret_cast<char*>(value.data()), store.constData() + offset, bytesToRead);
-        offset += bytesToRead;
-
-        return value;
-    }
-
-    void operator()(char* value_out, size_t value_size) {
-        checkReadSizeOk(value_size);
-        std::memcpy(value_out, store.constData() + offset, value_size);
-        offset += value_size;
-    }
-
-private:
-    void checkReadSizeOk(const size_t bytesToRead) const {
-        if (offset + bytesToRead > static_cast<size_t>(store.size()))
-            throw InternalError("Attempt to read past end of buffer");
-    }
-};
-
 
 /// TODO describe these
 /// This stores prefixes -> txids
@@ -136,7 +62,7 @@ struct ReusableBlock {
 
     // split hash into little nibbles so we can perform prefix queries on 4 bit sections
     // in future this can be expanded if we want even more fine grained queries, this (16bit) currently allows for 1/65536
-    static std::string ruHashToPrefix(const QByteArray &a) {
+    static std::string ruHashToPrefix(const RuHash &a) {
         if (a.size() < 2) throw BadArgs("Specified argument must be >=2 bytes in ReusableBlock::ruHashToPrefix!");
         return {{
             static_cast<char>((a[0] & 0xF0) >> NIBBLE_WIDTH), static_cast<char>(a[0] & 0x0F),
@@ -173,17 +99,8 @@ struct ReusableBlock {
     auto size() const -> decltype(pmap.size()) { return pmap.size(); }
 
     // serialization
-    QByteArray toBytes() const {
-        ReusableHATSerializer serializer;
-        pmap.serialize(serializer);
-        return serializer.store;
-    }
+    QByteArray toBytes() const;
 
     // deserialization
-    static ReusableBlock fromBytes(const QByteArray &ba) {
-        ReusableHATDeserializer deserializer(ba);
-        ReusableBlock ret;
-        ret.pmap = PrefixMap::deserialize(deserializer);
-        return ret;
-    }
+    static ReusableBlock fromBytes(const QByteArray &ba);
 };

--- a/src/ReusableBlock.h
+++ b/src/ReusableBlock.h
@@ -131,9 +131,7 @@ struct ReusableBlock {
 
     // perform serialization of a bitcoin input, the prefix of this will be indexed
     static RuHash serializeInput(const bitcoin::CTxIn& input) {
-        const auto serInput = BTC::Serialize(input);
-        RuHash ruHash = BTC::Hash(serInput, false); // double sha2
-        return ruHash;
+        return BTC::HashInPlace(input); // double sha256
     }
 
     // split hash into little nibbles so we can perform prefix queries on 4 bit sections


### PR DESCRIPTION
- Optimize the calculation of the "ruHash" to not allocate so much and use so much CPU by serializing directly to a "hasher".
- Refactor the code to not put so much noise into `ReusableBlock.h` and keep the serialization stuff "private" to the translation unit `ReusableBlock.cpp`
- Misc other small things